### PR TITLE
PA-220 inspector linking bug

### DIFF
--- a/src/main/resources/META-INF/props/web.properties
+++ b/src/main/resources/META-INF/props/web.properties
@@ -5,7 +5,7 @@ frontier.template.service.url = ${web.guidelines.template.service.url}
 pubmed.id.url = http://europepmc.org/abstract/MED/
 
 # ols url
-ols.accession.url = http://www.ebi.ac.uk/ontology-lookup/?termId=
+ols.accession.url = http://www.ebi.ac.uk/ols/search?q=
 
 # user web service urls
 user.signup.url = ${archive.user.signup.url}

--- a/src/main/webapp/WEB-INF/views/projectFileDownload.jsp
+++ b/src/main/webapp/WEB-INF/views/projectFileDownload.jsp
@@ -12,16 +12,16 @@
 
 <div class="grid_23 clearfix">
     <nav id="breadcrumb">
-    <p>
-        <spring:url var="prideUrl" value="//www.ebi.ac.uk/pride"/>
-        <spring:url var="priderUrl" value="/"/>
-        <spring:url var="projectUrl" value="/projects/{accession}">
-            <spring:param name="accession" value="${projectSummary.accession}"/>
-        </spring:url>
-        <a href="${prideUrl}"><fmt:message key="pride"/></a> &gt; <a href="${priderUrl}"><fmt:message
+        <p>
+            <spring:url var="prideUrl" value="//www.ebi.ac.uk/pride"/>
+            <spring:url var="priderUrl" value="/"/>
+            <spring:url var="projectUrl" value="/projects/{accession}">
+                <spring:param name="accession" value="${projectSummary.accession}"/>
+            </spring:url>
+            <a href="${prideUrl}"><fmt:message key="pride"/></a> &gt; <a href="${priderUrl}"><fmt:message
             key="prider"/> </a> &gt; <a href="${projectUrl}">${projectSummary.accession}</a> &gt;
-        <span><fmt:message key="download.files"/> </span>
-    </p>
+            <span><fmt:message key="download.files"/> </span>
+        </p>
     </nav>
 </div>
 
@@ -38,14 +38,16 @@
                            projectAccession="${projectSummary.accession}"
                            ftpRootAddress="ftp://ftp.pride.ebi.ac.uk/pride/data/archive"/>
         </c:if>
-         <%-- open pride inspector --%>
-        <fmt:message key="pride.inspector.title" var="inspectorTitle"/>
-        <h5>
+        <c:if test="${fn:toLowerCase(projectSummary.submissionType) != 'partial'}">
+            <%-- open pride inspector --%>
+            <fmt:message key="pride.inspector.title" var="inspectorTitle"/>
+            <h5>
             <span id="inspector-confirm" class="inspector_window icon icon-functional" data-icon="1" title="${inspectorTitle}">
-                ${inspectorTitle}
+                    ${inspectorTitle}
             </span>
-        </h5>
-        <inspector:inspectorDialog accession="${projectSummary.accession}" />
+            </h5>
+            <inspector:inspectorDialog accession="${projectSummary.accession}" />
+        </c:if>
     </div>
 </div>
 

--- a/src/main/webapp/WEB-INF/views/proteinsTable.jsp
+++ b/src/main/webapp/WEB-INF/views/proteinsTable.jsp
@@ -245,8 +245,8 @@
                             </spring:url>
                                 <fmt:message key="jump.peptide.table" var="jumpPeptideTable"/>
                                 <c:choose>
-                                    <c:when test="${fn:contains(highlights[protein], 'submitted_accession')}">
-                                        <c:forEach var="highlight" items="${highlights[protein]['submitted_accession']}">
+                                    <c:when test="${fn:contains(highlights[protein], 'accession')}">
+                                        <c:forEach var="highlight" items="${highlights[protein]['accession']}">
                                             <a href="${psmTableUrl}" title="${jumpPeptideTable}">${highlight}</a>
                                         </c:forEach>
                                     </c:when>
@@ -254,8 +254,6 @@
                                         <a href="${psmTableUrl}" title="${jumpPeptideTable}">${protein.submittedAccession}</a>
                                     </c:otherwise>
                                 </c:choose>
-
-
                             <%-- hyperlink to protein webapp view --%>
                             <spring:url var="proteinViewerUrl"
                                         value="/projects/{accession}/viewer/protein/{proteinID}">
@@ -349,7 +347,7 @@
                                             </c:when>
                                             <c:when test="${not fn:containsIgnoreCase(modification.value, 'UNIMOD:') and
                                                     not fn:containsIgnoreCase(modification.value, 'CHEMMOD:')}">
-                                                <spring:url var="url" value="http://www.ebi.ac.uk/ontology-lookup/?termId={accession}">
+                                                <spring:url var="url" value="http://www.ebi.ac.uk/ols/search?q={accession}">
                                                     <spring:param name="accession" value="${modification.value}"/>
                                                 </spring:url>
                                             </c:when>
@@ -357,7 +355,7 @@
                                                 <c:set var="url" value="" />
                                             </c:otherwise>
                                         </c:choose>
-                                        <spring:url var="olsUrl" value="http://www.ebi.ac.uk/ontology-lookup/?termId={accession}">
+                                        <spring:url var="olsUrl" value="http://www.ebi.ac.uk/ols/search?q={accession}">
                                             <spring:param name="accession" value="${modification.value}"/>
                                         </spring:url>
                                         <li>
@@ -378,47 +376,13 @@
                     <%-- Ambiguity group column--%>
                     <td>
                         <ul>
-                            <c:forEach var="submittedAccession" items="${protein.ambiguityGroupSubmittedAccessions}">
-                                <c:choose>
-                                    <c:when test="${fn:contains(highlights[protein], 'ambiguity_group')}">
-                                        <c:forEach var="highlight" items="${highlights[protein]['ambiguity_group']}">
-                                            <c:choose>
-                                                <c:when test="${fn:contains(highlight, submittedAccession)}">
-                                                    <li style="white-space: nowrap">${highlight}</li>
-                                                </c:when>
-                                                <c:otherwise>
-                                                    <li style="white-space: nowrap">${submittedAccession}</li>
-                                                </c:otherwise>
-                                            </c:choose>
-                                        </c:forEach>
-                                    </c:when>
-                                    <c:otherwise>
-                                        <li style="white-space: nowrap">${submittedAccession}</li>
-                                    </c:otherwise>
-                                </c:choose>
-                            </c:forEach>
+                            <li style="white-space: nowrap">${protein.submittedAccession}</li>
                         </ul>
                     </td>
                     <%-- Alternative mappings --%>
                     <td>
                         <c:forEach var="alternativeMapping" items="${protein.otherMappings}">
-                            <c:choose>
-                                <c:when test="${fn:contains(highlights[protein], 'other_mappings')}">
-                                    <c:forEach var="highlight" items="${highlights[protein]['other_mappings']}">
-                                        <c:choose>
-                                            <c:when test="${fn:contains(highlight, alternativeMapping)}">
-                                                ${highlight}
-                                            </c:when>
-                                            <c:otherwise>
-                                                ${alternativeMapping}
-                                            </c:otherwise>
-                                        </c:choose>
-                                    </c:forEach>
-                                </c:when>
-                                <c:otherwise>
-                                    ${alternativeMapping}
-                                </c:otherwise>
-                            </c:choose>
+                            ${alternativeMapping}
                         </c:forEach>
                     </td>
                 </tr>

--- a/src/main/webapp/WEB-INF/views/psmsTable.jsp
+++ b/src/main/webapp/WEB-INF/views/psmsTable.jsp
@@ -382,7 +382,7 @@
                                     </c:when>
                                     <c:when test="${not fn:containsIgnoreCase(modification.accession, 'UNIMOD:') and
                                                     not fn:containsIgnoreCase(modification.accession, 'CHEMMOD:')}">
-                                        <spring:url var="url" value="http://www.ebi.ac.uk/ontology-lookup/?termId={accession}">
+                                        <spring:url var="url" value="http://www.ebi.ac.uk/ols/search?q={accession}">
                                             <spring:param name="accession" value="${modification.accession}"/>
                                         </spring:url>
                                     </c:when>


### PR DESCRIPTION
I've fixed bugs to do with:
1.  PRIDE Inspector links appearing on 'partial' projects' Project Files page, this should not be happening - it should only appear for 'complete' or 'PRIDE' projects.
2. OLS links have now been corrected. Previously they were pointing to the old OLS URLs, e.g. linked to on the Proteins or PSM tables.
3. Improved the highlighting on the Proteins table, should no longer cause errors for the alternative mappings or ambiguity members columns.  